### PR TITLE
add migrations to gitignore file so that the migrations folder will be ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ db.sqlite3
 # Flask stuff:
 instance/
 .webassets-cache
+migrations/
 
 # Scrapy stuff:
 .scrapy


### PR DESCRIPTION
migration files are auto-generated files which are used for Flask database migration so that the `migrations` directory should not be pushed to git repository.