### PR TITLE
update vagrantfile to use a newer version of Ubuntu LTS

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,7 +12,7 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "ubuntu/bionic64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
Update Vagrantfile to use a newer version of Ubuntu LTS - 18.04