### PR TITLE
ignore db files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,8 +118,7 @@ db.sqlite3
 instance/
 .webassets-cache
 migrations/
-./db/development.db
-./db/test.db
+db/
 
 # Scrapy stuff:
 .scrapy


### PR DESCRIPTION
Ignore the *.db files in directory db/
The original ignore rules(./db/test.db) are not working.